### PR TITLE
Feature/my travel - FavoriteList

### DIFF
--- a/src/components/FavoriteHeart.jsx
+++ b/src/components/FavoriteHeart.jsx
@@ -8,11 +8,18 @@ const FavoriteHeart = ({
   initialFavorite = false,
   position = { top: "10px", right: "10px" },
   backgroundColor,
+  onFavoriteToggle,
 }) => {
   const [isFavorite, setIsFavorite] = useState(initialFavorite);
 
   const toggleFavorite = () => {
-    setIsFavorite((prev) => !prev);
+    setIsFavorite((prev) => {
+      const newFavorite = !prev;
+      if (!newFavorite) {
+        onFavoriteToggle();
+      }
+      return newFavorite;
+    });
   };
 
   return (
@@ -41,7 +48,7 @@ const HeartContainer = styled.div`
   border-radius: 8px;
 
   cursor: pointer;
-  z-index: 10;
+  z-index: 1;
   transition: color 0.2s ease;
 
   &:hover {

--- a/src/components/FavoriteHeart.jsx
+++ b/src/components/FavoriteHeart.jsx
@@ -1,0 +1,50 @@
+import React, { useState } from "react";
+import styled from "styled-components";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faHeart as filledHeart } from "@fortawesome/free-solid-svg-icons";
+import { faHeart as emptyHeart } from "@fortawesome/free-regular-svg-icons";
+
+const FavoriteHeart = ({
+  initialFavorite = false,
+  position = { top: "10px", right: "10px" },
+  backgroundColor,
+}) => {
+  const [isFavorite, setIsFavorite] = useState(initialFavorite);
+
+  const toggleFavorite = () => {
+    setIsFavorite((prev) => !prev);
+  };
+
+  return (
+    <HeartContainer
+      onClick={toggleFavorite}
+      isFavorite={isFavorite}
+      position={position}
+      backgroundColor={backgroundColor}
+    >
+      <FontAwesomeIcon icon={isFavorite ? filledHeart : emptyHeart} />
+    </HeartContainer>
+  );
+};
+
+export default FavoriteHeart;
+
+// 스타일 정의
+const HeartContainer = styled.div`
+  position: absolute;
+  top: ${(props) => props.position.top};
+  right: ${(props) => props.position.right};
+  font-size: 1.5rem;
+  background: ${(props) => props.backgroundColor};
+  color: ${(props) => (props.isFavorite ? "red" : "#fff")};
+  padding: 5px;
+  border-radius: 8px;
+
+  cursor: pointer;
+  z-index: 10;
+  transition: color 0.2s ease;
+
+  &:hover {
+    color: red;
+  }
+`;

--- a/src/components/FavoriteList.jsx
+++ b/src/components/FavoriteList.jsx
@@ -29,6 +29,15 @@ const FavoriteList = () => {
     fetchLocations();
   }, []);
 
+  const handleFavoriteToggle = (id) => {
+    setFavorites((prevFavorites) =>
+      prevFavorites.filter((item) => item.id !== id)
+    );
+  };
+
+  if (loading) return <p>로딩 중...</p>;
+  if (error) return <p>{error}</p>;
+
   return (
     <Container>
       {favorites.length === 0 ? (
@@ -40,6 +49,7 @@ const FavoriteList = () => {
               <FavoriteHeart
                 initialFavorite={item.likeStatus}
                 backgroundColor="#00000050"
+                onFavoriteToggle={() => handleFavoriteToggle(item.id)}
               />
               <TouristAttractionItem touristAttraction={item} width={"100%"} />
             </ItemWrapper>
@@ -62,7 +72,6 @@ const CardContainer = styled.div`
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;
-  gap: 20px;
   width: 100%;
 `;
 

--- a/src/components/FavoriteList.jsx
+++ b/src/components/FavoriteList.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import styled from "styled-components";
 import TouristAttractionItem from "./TouristAttractionItem";
+import FavoriteHeart from "./FavoriteHeart";
 import axios from "axios";
 
 const InterestList = () => {
@@ -35,7 +36,13 @@ const InterestList = () => {
       ) : (
         <CardContainer>
           {favorites.map((item) => (
-            <TouristAttractionItem key={item.id} touristAttraction={item} />
+            <ItemWrapper key={item.id}>
+              <FavoriteHeart
+                initialFavorite={item.likeStatus}
+                backgroundColor="#00000050"
+              />
+              <TouristAttractionItem touristAttraction={item} width={"100%"} />
+            </ItemWrapper>
           ))}
         </CardContainer>
       )}
@@ -55,4 +62,11 @@ const CardContainer = styled.div`
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;
+  gap: 20px;
+  width: 100%;
+`;
+
+const ItemWrapper = styled.div`
+  position: relative;
+  width: calc(25% - 20px);
 `;

--- a/src/components/FavoriteList.jsx
+++ b/src/components/FavoriteList.jsx
@@ -66,16 +66,19 @@ export default FavoriteList;
 const Container = styled.div`
   padding: 20px;
   background: #f9f9f9;
+  display: flex;
+  justify-content: center;
 `;
 
 const CardContainer = styled.div`
   display: flex;
   flex-wrap: wrap;
-  justify-content: space-between;
+  justify-content: flex-start;
+  gap: 20px;
   width: 100%;
 `;
 
 const ItemWrapper = styled.div`
   position: relative;
-  width: calc(25% - 20px);
+  width: calc(25% - 15px);
 `;

--- a/src/components/FavoriteList.jsx
+++ b/src/components/FavoriteList.jsx
@@ -4,7 +4,7 @@ import TouristAttractionItem from "./TouristAttractionItem";
 import FavoriteHeart from "./FavoriteHeart";
 import axios from "axios";
 
-const InterestList = () => {
+const FavoriteList = () => {
   const [favorites, setFavorites] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -50,7 +50,7 @@ const InterestList = () => {
   );
 };
 
-export default InterestList;
+export default FavoriteList;
 
 // 스타일 정의
 const Container = styled.div`

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -84,7 +84,7 @@ const HeaderArea = styled.header`
   display: flex;
   align-items: center;
   gap: 30px;
-  z-index: 1;
+  z-index: 2;
 `;
 
 const TItle = styled.h1`


### PR DESCRIPTION
**1) FavoriteHeart 컴포넌트 생성**
- 이후 **상세페이지**에서도 사용 가능하도록 수정할 예정.
-  **데이터 요청**도 이 컴포넌트에서 진행할 예정.
- **Debounce**로 최적화 예정.

**2) 하트를 클릭 시, 카드 삭제**
- 찜한 상태가 ```true```인 것만 가져오기 때문에, **클릭**하면 무조건 ```false```로 변경 및 카드 삭제.

**3) 카드 위에 하트 겹쳐서 배치**
- ```relative```와 ```absolute```를 이용하여, 겹칠 수 있게 설정.
- ```z-index: 1```을 줌으로써 카드보다 위에 배치.
- 문제점: header 위에도 하트가 올라감.

**4) header의 z-index 위치 수정**
⭐ 3)의 문제점을 해결을 위해, **header**의 ```z-index```를 ```2```로 수정.