### PR TITLE
Feature/main api - 여행지 정보 요청 API 연동

### DIFF
--- a/src/api/touristAttractionDetailsAPI.js
+++ b/src/api/touristAttractionDetailsAPI.js
@@ -1,0 +1,26 @@
+import { api } from "../utils/api";
+
+export const fetchTouristAttractionById = async (mapId) => {
+  try {
+    const response = await api.get(`/api/maps/${mapId}`);
+    const data = response.data;
+
+    return {
+      mapId: data.map_id,
+      name: data.place_name,
+      image: data.place_image,
+      info: data.place_details_info,
+      address: data.place_location,
+      lat: data.lat,
+      lng: data.lng,
+      favorite: data.favorite,
+      closeDate: data.close_date,
+      operationTime: data.operation_time,
+      contactNum: data.place_contact_num,
+    };
+  } catch (error) {
+    throw new Error(
+      `Error fetching tourist attraction details: ${error.message}`
+    );
+  }
+};

--- a/src/api/touristAttractionsAPI.js
+++ b/src/api/touristAttractionsAPI.js
@@ -1,0 +1,20 @@
+import { api } from "../utils/api";
+
+export const fetchTouristAttractions = async (page = 0, size = 12) => {
+  try {
+    const response = await api.get(`/api/maps?page=${page}&size=${size}`);
+
+    return {
+      maps: response.data.maps.map((item) => ({
+        id: item.map_id,
+        name: item.place_name,
+        image: item.place_image,
+        address: item.place_location,
+      })),
+      totalPages: response.data.totalPages,
+      currentPage: response.data.currentPage,
+    };
+  } catch (error) {
+    throw new Error(`Error fetching tourist attractions: ${error.message}`);
+  }
+};

--- a/src/components/Pagination.jsx
+++ b/src/components/Pagination.jsx
@@ -1,17 +1,17 @@
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faAngleLeft } from '@fortawesome/free-solid-svg-icons';
-import { faAngleRight } from '@fortawesome/free-solid-svg-icons';
-import styled from 'styled-components';
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faAngleLeft } from "@fortawesome/free-solid-svg-icons";
+import { faAngleRight } from "@fortawesome/free-solid-svg-icons";
+import styled from "styled-components";
 
 const Pagination = ({ currentPage, handleChangePage }) => {
   return (
     <ButtonContainer>
-      <button onClick={() => handleChangePage('prev')}>
-        <FontAwesomeIcon icon={faAngleLeft} size='2x' />
+      <button onClick={() => handleChangePage("prev")}>
+        <FontAwesomeIcon icon={faAngleLeft} size="2x" />
       </button>
-      <p>{currentPage}</p>
-      <button onClick={() => handleChangePage('next')}>
-        <FontAwesomeIcon icon={faAngleRight} size='2x' />
+      <p>{currentPage + 1}</p>
+      <button onClick={() => handleChangePage("next")}>
+        <FontAwesomeIcon icon={faAngleRight} size="2x" />
       </button>
     </ButtonContainer>
   );

--- a/src/components/TouristAttractionItem.jsx
+++ b/src/components/TouristAttractionItem.jsx
@@ -1,9 +1,9 @@
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faLocationDot } from '@fortawesome/free-solid-svg-icons';
-import styled from 'styled-components';
-import { useNavigate } from 'react-router';
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faLocationDot } from "@fortawesome/free-solid-svg-icons";
+import styled from "styled-components";
+import { useNavigate } from "react-router";
 
-const TouristAttractionItem = ({ touristAttraction, width = '312px' }) => {
+const TouristAttractionItem = ({ touristAttraction, width = "312px" }) => {
   const location = touristAttraction.address.slice(6, 9);
 
   const navigate = useNavigate();
@@ -12,20 +12,13 @@ const TouristAttractionItem = ({ touristAttraction, width = '312px' }) => {
     <Card
       width={width}
       onClick={() => {
-        navigate(`/tourist-attraction/${touristAttraction.id}`, {
-          state: {
-            id: touristAttraction.id,
-            name: touristAttraction.name,
-            image: touristAttraction.image,
-            address: touristAttraction.address,
-          },
-        });
+        navigate(`/tourist-attraction/${touristAttraction.id}`);
       }}
     >
       <CardBadge>{touristAttraction.name}</CardBadge>
       <img src={touristAttraction.image} alt={touristAttraction.name} />
       <CardLocation>
-        <FontAwesomeIcon icon={faLocationDot} size='lg' />
+        <FontAwesomeIcon icon={faLocationDot} size="lg" />
         <span>{location}</span>
       </CardLocation>
     </Card>

--- a/src/components/TouristAttractionList.jsx
+++ b/src/components/TouristAttractionList.jsx
@@ -1,51 +1,41 @@
 import styled from "styled-components";
 import TouristAttractionItem from "./TouristAttractionItem";
 import { useEffect, useState } from "react";
-import axios from "axios";
 import Pagination from "./Pagination";
+import { fetchTouristAttractions } from "../api/touristAttractionsAPI";
 
 const TouristAttractionList = () => {
   const [touristAttractions, setTouristAttractions] = useState([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState(null);
-  const [currentPage, setCurrentPage] = useState(1);
-  const [touristAttractionsPerPage, setTouristAttractionsPerPage] =
-    useState(12);
-
-  const fetchTouristAttraction = async () => {
-    try {
-      setIsLoading(true);
-
-      const response = await axios.get("./location.json");
-      const result = response.data;
-      setTouristAttractions(result);
-    } catch (error) {
-      setError(`Error / ${error}`);
-    } finally {
-      setIsLoading(false);
-    }
-  };
+  const [currentPage, setCurrentPage] = useState(0);
+  const [totalPages, setTotalPages] = useState(1);
+  const touristAttractionsPerPage = 12;
 
   useEffect(() => {
-    fetchTouristAttraction();
-  }, []);
+    const loadTouristAttractions = async () => {
+      try {
+        setIsLoading(true);
+        const data = await fetchTouristAttractions(
+          currentPage,
+          touristAttractionsPerPage
+        );
+        setTouristAttractions(data.maps);
+        setTotalPages(data.totalPages);
+      } catch (error) {
+        setError(error.message);
+      } finally {
+        setIsLoading(false);
+      }
+    };
 
-  const firstTouristAttractionIndex =
-    (currentPage - 1) * touristAttractionsPerPage;
-  const lastTouristAttractionIndex =
-    firstTouristAttractionIndex + touristAttractionsPerPage;
-  const currentTouristAttractions = touristAttractions.slice(
-    firstTouristAttractionIndex,
-    lastTouristAttractionIndex
-  );
-  const pageCount = Math.ceil(
-    touristAttractions.length / touristAttractionsPerPage
-  );
+    loadTouristAttractions();
+  }, [currentPage]);
 
   const handleChangePage = (selectedButton) => {
-    if (selectedButton === "prev" && currentPage !== 1) {
+    if (selectedButton === "prev" && currentPage > 1) {
       setCurrentPage((prevCurrentPage) => prevCurrentPage - 1);
-    } else if (selectedButton === "next" && currentPage !== pageCount) {
+    } else if (selectedButton === "next" && currentPage < totalPages) {
       setCurrentPage((prevCurrentPage) => prevCurrentPage + 1);
     }
   };
@@ -53,12 +43,16 @@ const TouristAttractionList = () => {
   let content = (
     <CardContainer>
       <CardList>
-        {currentTouristAttractions.map((touristAttraction) => (
-          <TouristAttractionItem
-            key={touristAttraction.id}
-            touristAttraction={touristAttraction}
-          />
-        ))}
+        {touristAttractions.length > 0 ? (
+          touristAttractions.map((touristAttraction) => (
+            <TouristAttractionItem
+              key={touristAttraction.id}
+              touristAttraction={touristAttraction}
+            />
+          ))
+        ) : (
+          <p>데이터가 없습니다.</p>
+        )}
       </CardList>
       <Pagination
         currentPage={currentPage}

--- a/src/pages/TouristAttractionDetail.jsx
+++ b/src/pages/TouristAttractionDetail.jsx
@@ -1,70 +1,90 @@
-import { faAngleLeft, faLocationDot } from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { useLocation, useNavigate } from 'react-router';
-import styled from 'styled-components';
-import GoogleMaps from '../components/GoogleMaps';
-import FavoriteHeart from '../components/FavoriteHeart';
-import { useState } from 'react';
+import {
+  faAngleLeft,
+  faLocationDot,
+  faPhone,
+  faShop,
+} from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { useLocation, useNavigate, useParams } from "react-router";
+import styled from "styled-components";
+import GoogleMaps from "../components/GoogleMaps";
+import FavoriteHeart from "../components/FavoriteHeart";
+import { useEffect, useState } from "react";
+import { fetchTouristAttractionById } from "../api/touristAttractionDetailsAPI";
 
 const TouristAttractionDetail = () => {
-  const [like, setLike] = useState(false);
+  const [touristAttraction, setTouristAttraction] = useState(null);
 
   const navigate = useNavigate();
-  const { state } = useLocation();
+  const { id } = useParams();
 
-  if (!state) {
-    return alert('데이터가 없습니다.');
+  useEffect(() => {
+    const loadTouristAttraction = async () => {
+      try {
+        const data = await fetchTouristAttractionById(id);
+        setTouristAttraction(data);
+      } catch (error) {
+        console.error(error);
+      }
+    };
+
+    loadTouristAttraction();
+  }, [id]);
+
+  if (!touristAttraction) {
+    return <p>로딩 중...</p>;
   }
-
-  const { id, name, image, address } = state;
-
-  // 마커 생성
-  const place = {
-    lat: 37.5665,
-    lng: 126.978,
-    title: '서울 시청',
-  };
-
-  const restaurants = [
-    { lat: 37.5633, lng: 126.9853, title: '명동교자' },
-    { lat: 37.5703, lng: 126.9976, title: '광장시장' },
-    { lat: 37.5652, lng: 126.9779, title: '팔선' },
-    { lat: 37.5631, lng: 126.9786, title: '백리향' },
-    { lat: 37.5707, lng: 126.9783, title: '광화문집' },
-    { lat: 37.5706, lng: 126.9753, title: '토속촌' },
-    { lat: 37.5558, lng: 126.9731, title: '서울역 한옥집' },
-    { lat: 37.5618, lng: 126.9766, title: '한양옥' },
-    { lat: 37.5641, lng: 126.9843, title: '명동밀면' },
-    { lat: 37.5662, lng: 126.9783, title: '서울식당' },
-  ];
 
   return (
     <>
       <ListView>
-        <BackButton onClick={() => navigate('/tourist-attraction')}>
-          <FontAwesomeIcon icon={faAngleLeft} size='2x' />
+        <BackButton onClick={() => navigate("/tourist-attraction")}>
+          <FontAwesomeIcon icon={faAngleLeft} size="2x" />
           <span>목록으로</span>
         </BackButton>
       </ListView>
       <LocationContainer>
         <LocationInfoArea>
           <LocationImage>
-            <img src={`/${image}`} alt='' />
+            <img src={touristAttraction.image} alt={touristAttraction.name} />
           </LocationImage>
           <LocationInfo>
             <TitleContainer>
-              <h3>{name}</h3>
-              <FavoriteHeart initialFavorite={false} mapId={id} pageType='detail' debounceTime={500} />
+              <h3>{touristAttraction.name}</h3>
+              <FavoriteHeart
+                initialFavorite={touristAttraction.favorite}
+                mapId={touristAttraction.mapId}
+                pageType="detail"
+                debounceTime={500}
+              />
             </TitleContainer>
             <p>
               <FontAwesomeIcon icon={faLocationDot} />
-              <span>{address}</span>
+              <span>{touristAttraction.address}</span>
             </p>
-            <p>조선 시대의 대표 궁궐로, 한국 전통 건축물의 아름다움을 감상할 수 있는 곳입니다.</p>
+            <p>
+              <FontAwesomeIcon icon={faPhone} />
+              <span>{touristAttraction.contactNum}</span>
+            </p>
+            <p>
+              <FontAwesomeIcon icon={faShop} />
+              <span>{touristAttraction.closeDate}</span>
+            </p>
+            <div className="operation-time">
+              <FontAwesomeIcon icon={faShop} />
+              <span>{touristAttraction.operationTime}</span>
+            </div>
+            <p>{touristAttraction.info}</p>
           </LocationInfo>
         </LocationInfoArea>
         <LocationMapArea>
-          <GoogleMaps place={place} restaurants={restaurants} />
+          <GoogleMaps
+            place={{
+              lat: touristAttraction.lat,
+              lng: touristAttraction.lng,
+              title: touristAttraction.name,
+            }}
+          />
         </LocationMapArea>
       </LocationContainer>
     </>
@@ -117,7 +137,7 @@ const LocationInfo = styled.div`
   display: flex;
   flex-direction: column;
   gap: 20px;
-  padding: 20px 0 20px 30px;
+  padding: 0 0 20px 30px;
   position: relative;
 
   & h3 {
@@ -133,6 +153,15 @@ const LocationInfo = styled.div`
     max-height: 278px;
     overflow-y: auto;
     padding: 1px 0;
+  }
+
+  .operation-time {
+    display: flex;
+    align-items: start;
+  }
+
+  .operation-time span {
+    white-space: pre-line;
   }
 `;
 


### PR DESCRIPTION
**1) 여행지 메인 정보 요청 API 연동**
- **```touristAttractionsAPI.js```**
- ```prameters```: 
    - ```page```: 해당 페이지 위치
    - ```size```: 페이지당 여행지 카드 수
- ```maps```: ```id```, ```name```, ```image```, ```address```
- ```totalPages```: 페이지네이션 전체 페이지 수
- ```currentPage```: 현재 페이지 위치

**2) 여행지 상세 정보 요청 API 연동**
- **```touristAttractionDetailsAPI.js```**
- ```parameters```:
    - ```mapId```: 여행지 데이터 id
- 추가된 데이터:
    - ```closeDate```: 휴무일
    - ```operationTime```: 영업시간
    - ```contactNum```: 전화번호

**3) 여행지 메인에서 상세로 state 넘기지 않음.**
- 데이터 **의존성**과 **복잡성**으로 인해 간단하게 ```id```만 주소로 전달.
- ```Params()```로 주소에서 id 정보를 가지고 옴. → 새로고침해도 지워지지 않음.

**4) 페이지네이션 시작이 0부터 시작하여 ```+1```하여 출력.**
