### PR TITLE
Feature/goods api - 굿즈 메인 및 상세 정보 요청 API 연동

### DIFF
--- a/src/api/goodDetailsAPI.js
+++ b/src/api/goodDetailsAPI.js
@@ -1,0 +1,20 @@
+import { api } from "../utils/api";
+
+export const fetchGoodDetails = async (goodId) => {
+  try {
+    const response = await api.get(`/api/goods/${goodId}`);
+    const data = response.data;
+
+    return {
+      id: data.goodId,
+      name: data.goodName,
+      imageUrl: data.goodImage,
+      price: data.goodPrice,
+      stock: data.goodStock,
+      description: data.goodDescription,
+    };
+  } catch (error) {
+    console.error("굿즈 상세 조회 오류:", error);
+    throw error;
+  }
+};

--- a/src/api/goodsAPI.js
+++ b/src/api/goodsAPI.js
@@ -1,0 +1,23 @@
+import { api } from "../utils/api";
+
+export const fetchGoods = async (page = 0, size = 12) => {
+  try {
+    const response = await api.get(`/api/goods?page=${page}&size=${size}`);
+    const result = response.data;
+
+    return {
+      goods: result.content.map((item) => ({
+        id: item.goodsId,
+        imgUrl: item.goodsImage,
+        title: item.goodsName,
+        price: item.goodsPrice,
+      })),
+      totalPages: result.page.totalPages,
+      currentPage: result.page.number,
+    };
+  } catch (error) {
+    throw new Error(
+      error.response?.data?.message || "상품 데이터를 불러오는 데 실패했습니다."
+    );
+  }
+};

--- a/src/api/goodsAPI.js
+++ b/src/api/goodsAPI.js
@@ -1,9 +1,36 @@
 import { api } from "../utils/api";
 
 export const fetchGoods = async (page = 0, size = 12) => {
+  console.log("page: ", page, "size: ", size);
   try {
     const response = await api.get(`/api/goods?page=${page}&size=${size}`);
     const result = response.data;
+    console.log(result);
+
+    return {
+      goods: result.content.map((item) => ({
+        id: item.goodsId,
+        imgUrl: item.goodsImage,
+        title: item.goodsName,
+        price: item.goodsPrice,
+      })),
+      totalPages: result.page.totalPages,
+      currentPage: result.page.number,
+    };
+  } catch (error) {
+    throw new Error(
+      error.response?.data?.message || "상품 데이터를 불러오는 데 실패했습니다."
+    );
+  }
+};
+
+export const fetchCategoryGoods = async (page = 0, size = 12, category) => {
+  try {
+    const response = await api.get(
+      `/api/goods/category/${category}?page=${page}`
+    );
+    const result = response.data;
+    console.log(result);
 
     return {
       goods: result.content.map((item) => ({

--- a/src/index.js
+++ b/src/index.js
@@ -9,13 +9,13 @@ import { store } from "./app/store";
 
 const root = ReactDOM.createRoot(document.getElementById("root"));
 root.render(
-  // <React.StrictMode>
-  <Provider store={store}>
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
-  </Provider>
-  // </React.StrictMode>
+  <React.StrictMode>
+    <Provider store={store}>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </Provider>
+  </React.StrictMode>
 );
 
 // If you want to start measuring performance in your app, pass a function

--- a/src/index.js
+++ b/src/index.js
@@ -9,13 +9,13 @@ import { store } from "./app/store";
 
 const root = ReactDOM.createRoot(document.getElementById("root"));
 root.render(
-  <React.StrictMode>
-    <Provider store={store}>
-      <BrowserRouter>
-        <App />
-      </BrowserRouter>
-    </Provider>
-  </React.StrictMode>
+  // <React.StrictMode>
+  <Provider store={store}>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </Provider>
+  // </React.StrictMode>
 );
 
 // If you want to start measuring performance in your app, pass a function

--- a/src/pages/Goods.jsx
+++ b/src/pages/Goods.jsx
@@ -1,41 +1,36 @@
 import { useEffect, useRef, useState } from "react";
-import axios from "axios";
 import Pagination from "../components/Pagination";
 import styled from "styled-components";
-import { useDispatch } from "react-redux";
-import { addGoods } from "../features/goodsSlice";
 import GoodsList from "../components/GoodsList";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faAngleDown, faAngleRight } from "@fortawesome/free-solid-svg-icons";
+import { fetchGoods } from "../api/goodsAPI";
 
 const Goods = () => {
   const [allProducts, setAllProducts] = useState([]);
   const [filteredProducts, setFilteredProducts] = useState([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState(null);
-  const [currentPage, setCurrentPage] = useState(1);
-  const [perPage, setPerPage] = useState(12);
+  const [currentPage, setCurrentPage] = useState(0);
   const [category, setCategory] = useState("전체");
   const [showCategory, setShowCategory] = useState(false);
 
-  const dispatch = useDispatch();
   const categoryRef = useRef(null);
   const optionListRef = useRef(null);
 
-  const startIndex = (currentPage - 1) * perPage;
-  const endIndex = startIndex + perPage;
-  const currentProducts = filteredProducts.slice(startIndex, endIndex);
-  const pageCount = Math.ceil(filteredProducts.length / perPage);
+  const goodsPerPage = 12;
 
-  async function fetchGoods() {
+  const startIndex = currentPage * goodsPerPage;
+  const endIndex = startIndex + goodsPerPage;
+  const currentProducts = filteredProducts.slice(startIndex, endIndex);
+  const pageCount = Math.ceil(filteredProducts.length / goodsPerPage);
+
+  async function fetchGoodsData() {
     setIsLoading(true);
 
     try {
-      const response = await axios.get("goods.json");
-      const result = response.data;
-      setAllProducts(result);
-      // setFilteredProducts(result);
-      dispatch(addGoods(result));
+      const data = await fetchGoods(currentPage, goodsPerPage);
+      setAllProducts(data.goods);
     } catch (error) {
       setError(error.message);
     } finally {
@@ -55,8 +50,8 @@ const Goods = () => {
   }
 
   useEffect(() => {
-    fetchGoods();
-  }, []);
+    fetchGoodsData();
+  }, [currentPage]);
 
   useEffect(() => {
     if (category === "전체") {
@@ -68,7 +63,7 @@ const Goods = () => {
       setFilteredProducts(newProducts);
     }
 
-    setCurrentPage(1);
+    setCurrentPage(0);
   }, [category, allProducts]);
 
   useEffect(() => {

--- a/src/pages/Goods.jsx
+++ b/src/pages/Goods.jsx
@@ -4,14 +4,14 @@ import styled from "styled-components";
 import GoodsList from "../components/GoodsList";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faAngleDown, faAngleRight } from "@fortawesome/free-solid-svg-icons";
-import { fetchGoods } from "../api/goodsAPI";
+import { fetchGoods, fetchCategoryGoods } from "../api/goodsAPI";
 
 const Goods = () => {
   const [allProducts, setAllProducts] = useState([]);
-  const [filteredProducts, setFilteredProducts] = useState([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState(null);
   const [currentPage, setCurrentPage] = useState(0);
+  const [totalPages, setTotalPages] = useState(1);
   const [category, setCategory] = useState("전체");
   const [showCategory, setShowCategory] = useState(false);
 
@@ -22,15 +22,22 @@ const Goods = () => {
 
   const startIndex = currentPage * goodsPerPage;
   const endIndex = startIndex + goodsPerPage;
-  const currentProducts = filteredProducts.slice(startIndex, endIndex);
-  const pageCount = Math.ceil(filteredProducts.length / goodsPerPage);
+  const currentProducts = allProducts.slice(startIndex, endIndex);
 
   async function fetchGoodsData() {
     setIsLoading(true);
-
     try {
-      const data = await fetchGoods(currentPage, goodsPerPage);
-      setAllProducts(data.goods);
+      let data;
+      if (category === "전체") {
+        data = await fetchGoods(currentPage, goodsPerPage);
+      } else {
+        data = await fetchCategoryGoods(currentPage, goodsPerPage, category);
+      }
+
+      setAllProducts((prevProducts) =>
+        currentPage === 0 ? data.goods : [...prevProducts, ...data.goods]
+      ); // 페이지가 0이면 새로 덮어쓰고, 아니면 기존 데이터에 추가
+      setTotalPages(data.totalPages);
     } catch (error) {
       setError(error.message);
     } finally {
@@ -46,25 +53,13 @@ const Goods = () => {
     if (e.target.tagName === "LI") {
       setShowCategory(false);
       setCategory(e.target.textContent);
+      setCurrentPage(0);
     }
   }
 
   useEffect(() => {
     fetchGoodsData();
-  }, [currentPage]);
-
-  useEffect(() => {
-    if (category === "전체") {
-      setFilteredProducts(allProducts);
-    } else {
-      const newProducts = allProducts.filter(
-        (item) => item.category === category
-      );
-      setFilteredProducts(newProducts);
-    }
-
-    setCurrentPage(0);
-  }, [category, allProducts]);
+  }, [currentPage, category]);
 
   useEffect(() => {
     function handleClickOutside(e) {
@@ -85,9 +80,9 @@ const Goods = () => {
   }, []);
 
   const handleChangePage = (selectedButton) => {
-    if (selectedButton === "prev" && currentPage !== 1) {
+    if (selectedButton === "prev" && currentPage > 0) {
       setCurrentPage((prevCurrentPage) => prevCurrentPage - 1);
-    } else if (selectedButton === "next" && currentPage !== pageCount) {
+    } else if (selectedButton === "next" && currentPage < totalPages - 1) {
       setCurrentPage((prevCurrentPage) => prevCurrentPage + 1);
     }
   };
@@ -118,7 +113,7 @@ const Goods = () => {
               <Option>전체</Option>
               <Option>패션생활용품</Option>
               <Option>공예품</Option>
-              <Option>인테리어 소품</Option>
+              <Option>인테리어소품</Option>
             </OptionList>
           )}
         </Category>

--- a/src/pages/Goods.jsx
+++ b/src/pages/Goods.jsx
@@ -1,12 +1,12 @@
-import { useEffect, useRef, useState } from 'react';
-import axios from 'axios';
-import Pagination from '../components/Pagination';
-import styled from 'styled-components';
-import { useDispatch } from 'react-redux';
-import { addGoods } from '../features/goodsSlice';
-import GoodsList from '../components/GoodsList';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faAngleDown, faAngleRight } from '@fortawesome/free-solid-svg-icons';
+import { useEffect, useRef, useState } from "react";
+import axios from "axios";
+import Pagination from "../components/Pagination";
+import styled from "styled-components";
+import { useDispatch } from "react-redux";
+import { addGoods } from "../features/goodsSlice";
+import GoodsList from "../components/GoodsList";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faAngleDown, faAngleRight } from "@fortawesome/free-solid-svg-icons";
 
 const Goods = () => {
   const [allProducts, setAllProducts] = useState([]);
@@ -15,7 +15,7 @@ const Goods = () => {
   const [error, setError] = useState(null);
   const [currentPage, setCurrentPage] = useState(1);
   const [perPage, setPerPage] = useState(12);
-  const [category, setCategory] = useState('전체');
+  const [category, setCategory] = useState("전체");
   const [showCategory, setShowCategory] = useState(false);
 
   const dispatch = useDispatch();
@@ -31,7 +31,7 @@ const Goods = () => {
     setIsLoading(true);
 
     try {
-      const response = await axios.get('goods.json');
+      const response = await axios.get("goods.json");
       const result = response.data;
       setAllProducts(result);
       // setFilteredProducts(result);
@@ -48,7 +48,7 @@ const Goods = () => {
   }
 
   function handleSelectedOption(e) {
-    if (e.target.tagName === 'LI') {
+    if (e.target.tagName === "LI") {
       setShowCategory(false);
       setCategory(e.target.textContent);
     }
@@ -59,10 +59,12 @@ const Goods = () => {
   }, []);
 
   useEffect(() => {
-    if (category === '전체') {
+    if (category === "전체") {
       setFilteredProducts(allProducts);
     } else {
-      const newProducts = allProducts.filter((item) => item.category === category);
+      const newProducts = allProducts.filter(
+        (item) => item.category === category
+      );
       setFilteredProducts(newProducts);
     }
 
@@ -71,22 +73,26 @@ const Goods = () => {
 
   useEffect(() => {
     function handleClickOutside(e) {
-      if (categoryRef.current && !categoryRef.current.contains(e.target) && e.target !== optionListRef.current) {
+      if (
+        categoryRef.current &&
+        !categoryRef.current.contains(e.target) &&
+        e.target !== optionListRef.current
+      ) {
         setShowCategory(false);
       }
     }
 
-    document.addEventListener('click', handleClickOutside);
+    document.addEventListener("click", handleClickOutside);
 
     return () => {
-      document.removeEventListener('click', handleClickOutside);
+      document.removeEventListener("click", handleClickOutside);
     };
   }, []);
 
   const handleChangePage = (selectedButton) => {
-    if (selectedButton === 'prev' && currentPage !== 1) {
+    if (selectedButton === "prev" && currentPage !== 1) {
       setCurrentPage((prevCurrentPage) => prevCurrentPage - 1);
-    } else if (selectedButton === 'next' && currentPage !== pageCount) {
+    } else if (selectedButton === "next" && currentPage !== pageCount) {
       setCurrentPage((prevCurrentPage) => prevCurrentPage + 1);
     }
   };
@@ -106,7 +112,11 @@ const Goods = () => {
           <span>카테고리 : </span>
           <CurrentOption onClick={handleToggleCategory} ref={categoryRef}>
             <span>{category}</span>
-            {showCategory ? <FontAwesomeIcon icon={faAngleDown} /> : <FontAwesomeIcon icon={faAngleRight} />}
+            {showCategory ? (
+              <FontAwesomeIcon icon={faAngleDown} />
+            ) : (
+              <FontAwesomeIcon icon={faAngleRight} />
+            )}
           </CurrentOption>
           {showCategory && (
             <OptionList onClick={handleSelectedOption} ref={optionListRef}>
@@ -119,7 +129,10 @@ const Goods = () => {
         </Category>
         <GoodsList currentProducts={currentProducts} />
       </Container>
-      <Pagination currentPage={currentPage} handleChangePage={handleChangePage} />
+      <Pagination
+        currentPage={currentPage}
+        handleChangePage={handleChangePage}
+      />
     </>
   );
 };

--- a/src/pages/GoodsDetail.jsx
+++ b/src/pages/GoodsDetail.jsx
@@ -1,37 +1,19 @@
-import {
-  faAngleLeft,
-  faCartPlus,
-  faCreditCard,
-} from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { useEffect, useState } from "react";
-import { Link, useParams } from "react-router";
-import styled from "styled-components";
-import { Modal } from "../components/Modal";
-import { fetchGoodDetails } from "../api/goodDetailsAPI";
+import { faAngleLeft, faCartPlus, faCreditCard } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { useState } from 'react';
+import { useSelector } from 'react-redux';
+import { Link, useParams } from 'react-router';
+import styled from 'styled-components';
+import { Modal } from '../components/Modal';
 
 const GoodsDetail = () => {
   const [showModal, setShowModal] = useState(false);
   const [user, setUser] = useState(null);
-  const [goods, setGoods] = useState(null);
-  const [loading, setLoading] = useState(true);
 
   const { id } = useParams();
+  const goods = useSelector((state) => state.goods);
 
-  useEffect(() => {
-    const getGoodsDetails = async () => {
-      setLoading(true);
-      try {
-        const data = await fetchGoodDetails(id);
-        setGoods(data);
-      } catch (error) {
-        console.error("굿즈 데이터를 가져오는 중 오류 발생:", error);
-      }
-      setLoading(false);
-    };
-
-    getGoodsDetails();
-  }, [id]);
+  const currentGoods = goods.find((item) => item.id === +id);
 
   function handleAddCart() {
     setShowModal(true);
@@ -40,9 +22,6 @@ const GoodsDetail = () => {
   function handleCloseModal() {
     setShowModal(false);
   }
-
-  if (loading) return <p>로딩 중...</p>;
-  if (!goods) return <p>상품 정보를 불러올 수 없습니다.</p>;
 
   return (
     <Container>
@@ -61,30 +40,29 @@ const GoodsDetail = () => {
               </>
             )}
           </Content>
-          <LinkStyle to={"/login"}>확인</LinkStyle>
+          <LinkStyle to={'/login'}>확인</LinkStyle>
           <button onClick={handleCloseModal}>취소</button>
         </Modal>
       )}
 
-      <ListLink to={"/goods"}>
-        <FontAwesomeIcon icon={faAngleLeft} size="2x" />
+      <ListLink to={'/goods'}>
+        <FontAwesomeIcon icon={faAngleLeft} size='2x' />
         <span>목록으로</span>
       </ListLink>
 
       <Product>
-        <img src={goods.imageUrl} alt={goods.name} />
+        <img src={currentGoods.imgUrl} alt={currentGoods.title} />
         <Info>
-          <Title>{goods.name}</Title>
-          <Category>{goods.category || "카테고리 없음"}</Category>
-          <p>{goods.description}</p>
-          <Price>가격 : {goods.price}원</Price>
-          <Stock>재고: {goods.stock}개</Stock>
+          <Title>{currentGoods.title}</Title>
+          <Category>{currentGoods.category}</Category>
+          <p>{currentGoods.description}</p>
+          <Price>가격 : {currentGoods.price}</Price>
           <Buttons>
             <button>
-              <FontAwesomeIcon icon={faCreditCard} size="2x" />
+              <FontAwesomeIcon icon={faCreditCard} size='2x' />
             </button>
             <button onClick={handleAddCart}>
-              <FontAwesomeIcon icon={faCartPlus} size="2x" />
+              <FontAwesomeIcon icon={faCartPlus} size='2x' />
             </button>
           </Buttons>
         </Info>
@@ -148,10 +126,6 @@ const Category = styled.p`
 
 const Price = styled.p`
   font-size: 20px;
-`;
-
-const Stock = styled.p`
-  opacity: 0.5;
 `;
 
 const Buttons = styled.div`

--- a/src/pages/GoodsDetail.jsx
+++ b/src/pages/GoodsDetail.jsx
@@ -1,19 +1,37 @@
-import { faAngleLeft, faCartPlus, faCreditCard } from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { useState } from 'react';
-import { useSelector } from 'react-redux';
-import { Link, useParams } from 'react-router';
-import styled from 'styled-components';
-import { Modal } from '../components/Modal';
+import {
+  faAngleLeft,
+  faCartPlus,
+  faCreditCard,
+} from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { useEffect, useState } from "react";
+import { Link, useParams } from "react-router";
+import styled from "styled-components";
+import { Modal } from "../components/Modal";
+import { fetchGoodDetails } from "../api/goodDetailsAPI";
 
 const GoodsDetail = () => {
   const [showModal, setShowModal] = useState(false);
   const [user, setUser] = useState(null);
+  const [goods, setGoods] = useState(null);
+  const [loading, setLoading] = useState(true);
 
   const { id } = useParams();
-  const goods = useSelector((state) => state.goods);
 
-  const currentGoods = goods.find((item) => item.id === +id);
+  useEffect(() => {
+    const getGoodsDetails = async () => {
+      setLoading(true);
+      try {
+        const data = await fetchGoodDetails(id);
+        setGoods(data);
+      } catch (error) {
+        console.error("굿즈 데이터를 가져오는 중 오류 발생:", error);
+      }
+      setLoading(false);
+    };
+
+    getGoodsDetails();
+  }, [id]);
 
   function handleAddCart() {
     setShowModal(true);
@@ -22,6 +40,9 @@ const GoodsDetail = () => {
   function handleCloseModal() {
     setShowModal(false);
   }
+
+  if (loading) return <p>로딩 중...</p>;
+  if (!goods) return <p>상품 정보를 불러올 수 없습니다.</p>;
 
   return (
     <Container>
@@ -40,29 +61,30 @@ const GoodsDetail = () => {
               </>
             )}
           </Content>
-          <LinkStyle to={'/login'}>확인</LinkStyle>
+          <LinkStyle to={"/login"}>확인</LinkStyle>
           <button onClick={handleCloseModal}>취소</button>
         </Modal>
       )}
 
-      <ListLink to={'/goods'}>
-        <FontAwesomeIcon icon={faAngleLeft} size='2x' />
+      <ListLink to={"/goods"}>
+        <FontAwesomeIcon icon={faAngleLeft} size="2x" />
         <span>목록으로</span>
       </ListLink>
 
       <Product>
-        <img src={currentGoods.imgUrl} alt={currentGoods.title} />
+        <img src={goods.imageUrl} alt={goods.name} />
         <Info>
-          <Title>{currentGoods.title}</Title>
-          <Category>{currentGoods.category}</Category>
-          <p>{currentGoods.description}</p>
-          <Price>가격 : {currentGoods.price}</Price>
+          <Title>{goods.name}</Title>
+          <Category>{goods.category || "카테고리 없음"}</Category>
+          <p>{goods.description}</p>
+          <Price>가격 : {goods.price}원</Price>
+          <Stock>재고 : {goods.stock}개</Stock>
           <Buttons>
             <button>
-              <FontAwesomeIcon icon={faCreditCard} size='2x' />
+              <FontAwesomeIcon icon={faCreditCard} size="2x" />
             </button>
             <button onClick={handleAddCart}>
-              <FontAwesomeIcon icon={faCartPlus} size='2x' />
+              <FontAwesomeIcon icon={faCartPlus} size="2x" />
             </button>
           </Buttons>
         </Info>
@@ -126,6 +148,10 @@ const Category = styled.p`
 
 const Price = styled.p`
   font-size: 20px;
+`;
+
+const Stock = styled.p`
+  opacity: 0.5;
 `;
 
 const Buttons = styled.div`

--- a/src/pages/GoodsDetail.jsx
+++ b/src/pages/GoodsDetail.jsx
@@ -1,19 +1,37 @@
-import { faAngleLeft, faCartPlus, faCreditCard } from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { useState } from 'react';
-import { useSelector } from 'react-redux';
-import { Link, useParams } from 'react-router';
-import styled from 'styled-components';
-import { Modal } from '../components/Modal';
+import {
+  faAngleLeft,
+  faCartPlus,
+  faCreditCard,
+} from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { useEffect, useState } from "react";
+import { Link, useParams } from "react-router";
+import styled from "styled-components";
+import { Modal } from "../components/Modal";
+import { fetchGoodDetails } from "../api/goodDetailsAPI";
 
 const GoodsDetail = () => {
   const [showModal, setShowModal] = useState(false);
   const [user, setUser] = useState(null);
+  const [goods, setGoods] = useState(null);
+  const [loading, setLoading] = useState(true);
 
   const { id } = useParams();
-  const goods = useSelector((state) => state.goods);
 
-  const currentGoods = goods.find((item) => item.id === +id);
+  useEffect(() => {
+    const getGoodsDetails = async () => {
+      setLoading(true);
+      try {
+        const data = await fetchGoodDetails(id);
+        setGoods(data);
+      } catch (error) {
+        console.error("굿즈 데이터를 가져오는 중 오류 발생:", error);
+      }
+      setLoading(false);
+    };
+
+    getGoodsDetails();
+  }, [id]);
 
   function handleAddCart() {
     setShowModal(true);
@@ -22,6 +40,9 @@ const GoodsDetail = () => {
   function handleCloseModal() {
     setShowModal(false);
   }
+
+  if (loading) return <p>로딩 중...</p>;
+  if (!goods) return <p>상품 정보를 불러올 수 없습니다.</p>;
 
   return (
     <Container>
@@ -40,29 +61,30 @@ const GoodsDetail = () => {
               </>
             )}
           </Content>
-          <LinkStyle to={'/login'}>확인</LinkStyle>
+          <LinkStyle to={"/login"}>확인</LinkStyle>
           <button onClick={handleCloseModal}>취소</button>
         </Modal>
       )}
 
-      <ListLink to={'/goods'}>
-        <FontAwesomeIcon icon={faAngleLeft} size='2x' />
+      <ListLink to={"/goods"}>
+        <FontAwesomeIcon icon={faAngleLeft} size="2x" />
         <span>목록으로</span>
       </ListLink>
 
       <Product>
-        <img src={currentGoods.imgUrl} alt={currentGoods.title} />
+        <img src={goods.imageUrl} alt={goods.name} />
         <Info>
-          <Title>{currentGoods.title}</Title>
-          <Category>{currentGoods.category}</Category>
-          <p>{currentGoods.description}</p>
-          <Price>가격 : {currentGoods.price}</Price>
+          <Title>{goods.name}</Title>
+          <Category>{goods.category || "카테고리 없음"}</Category>
+          <p>{goods.description}</p>
+          <Price>가격 : {goods.price}원</Price>
+          <Stock>재고: {goods.stock}개</Stock>
           <Buttons>
             <button>
-              <FontAwesomeIcon icon={faCreditCard} size='2x' />
+              <FontAwesomeIcon icon={faCreditCard} size="2x" />
             </button>
             <button onClick={handleAddCart}>
-              <FontAwesomeIcon icon={faCartPlus} size='2x' />
+              <FontAwesomeIcon icon={faCartPlus} size="2x" />
             </button>
           </Buttons>
         </Info>
@@ -126,6 +148,10 @@ const Category = styled.p`
 
 const Price = styled.p`
   font-size: 20px;
+`;
+
+const Stock = styled.p`
+  opacity: 0.5;
 `;
 
 const Buttons = styled.div`


### PR DESCRIPTION
**1) 굿즈 메인 정보 요청 API**
- ```goodsAPI.js```
    - **```fetchGoods``` 함수:** 
        - 페이지네이션이 적용된 12개의 굿즈 데이터를 요청.
        - ```page```: 현재 페이지, ```size```: 페이지당 카드 수
    - **```fetchCategoryGoods``` 함수:**
    - 카테고리별로 페이지네이션을 적용하여 굿즈 데이터를 요청.
    ⛔현재 카테고리 `패션생활용품`의 데이터가 오지 않는 문제가 발생하여 백엔드 측에서 해결 중.

**2) 굿즈 상세 정보 요청 API**
- ```goodDetailsAPI.js```
    - ```fetchGoodDetails``` 함수:
        - ```goodId```: 상품 id를 메인 정보에서 받음.

⭐```stock(재고)``` 데이터 추가