### PR TITLE
feat: 로그인 여부에 따른, 여행지 상세 정보 API 인증 헤더 추가

### DIFF
--- a/src/api/touristAttractionDetailsAPI.js
+++ b/src/api/touristAttractionDetailsAPI.js
@@ -1,9 +1,26 @@
 import { api } from "../utils/api";
+import { getAccessToken } from "../utils/decodeToken";
+
+const getAuthHeaders = () => {
+  const accessToken = getAccessToken();
+
+  const headers = accessToken
+    ? {
+        Authorization: `Bearer ${accessToken}`,
+      }
+    : null;
+
+  return headers;
+};
 
 export const fetchTouristAttractionById = async (mapId) => {
+  const headers = getAuthHeaders();
+  console.log("headers: ", headers);
+
   try {
-    const response = await api.get(`/api/maps/${mapId}`);
+    const response = await api.get(`/api/maps/${mapId}`, { headers });
     const data = response.data;
+    console.log("여행지 상세 페이지 정보: ", data);
 
     return {
       mapId: data.map_id,


### PR DESCRIPTION
- 로그인 여부 확인 후, header에 인증 헤더 추가.
- **로그인 O**: **accessToken을 인증 헤더**에 같이 전송.
- **로그인 X**: 인증 헤더를 제외하고 **바로 API 요청**.
- 이유: favorite(찜) 값이 로그인 인증에 따라서 값을 받아오고, 나머지 값들은 비회원, 회원 둘 다 가지고 와야 하는 데이터이기 때문에 분리해서 처리.