### PR TITLE
Feature/cart connection - 장바구니 이동 모달 및 API 연동 (굿즈 메인 페이지)

### DIFF
--- a/src/api/cartAPI.js
+++ b/src/api/cartAPI.js
@@ -1,0 +1,26 @@
+import { authApi } from "../utils/authApi";
+import { getAccessToken, getUserIdFromToken } from "../utils/decodeToken";
+
+export const addItemToCart = async (goodId, quantity) => {
+  const accessToken = getAccessToken();
+  const userId = getUserIdFromToken();
+
+  const addItem = {
+    userId,
+    goodId,
+    quantity,
+  };
+
+  try {
+    const response = await authApi.post("/cart/add", addItem, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+
+    console.log("카트에 성공적으로 추가하였습니다. : ", response.data);
+    return response.data;
+  } catch (error) {
+    throw new Error(
+      error.response?.data?.message || "🚨카트에 추가하기를 실패하였습니다."
+    );
+  }
+};

--- a/src/components/CartConfirmModal.jsx
+++ b/src/components/CartConfirmModal.jsx
@@ -3,7 +3,7 @@ import React from "react";
 import { Link } from "react-router";
 import styled from "styled-components";
 
-const CartConfirmModal = ({ user, handleCloseModal }) => {
+const CartConfirmModal = ({ user, handleCloseModal, message }) => {
   const page = user ? "/cart" : "/login";
 
   return (
@@ -11,8 +11,7 @@ const CartConfirmModal = ({ user, handleCloseModal }) => {
       <Content>
         {user ? (
           <>
-            <p>장바구니에 담았습니다</p>
-            <p>장바구니 페이지로 이동하시겠습니까?</p>
+            <p>{message}</p>
           </>
         ) : (
           <>
@@ -29,6 +28,7 @@ const CartConfirmModal = ({ user, handleCloseModal }) => {
 
 const Content = styled.div`
   line-height: 35px;
+  white-space: pre-line;
 `;
 
 const LinkStyle = styled(Link)`

--- a/src/components/CartConfirmModal.jsx
+++ b/src/components/CartConfirmModal.jsx
@@ -1,0 +1,50 @@
+import { Modal } from "./Modal";
+import React from "react";
+import { Link } from "react-router";
+import styled from "styled-components";
+
+const CartConfirmModal = ({ user, handleCloseModal }) => {
+  const page = user ? "/cart" : "/login";
+
+  return (
+    <Modal>
+      <Content>
+        {user ? (
+          <>
+            <p>장바구니에 담았습니다</p>
+            <p>장바구니 페이지로 이동하시겠습니까?</p>
+          </>
+        ) : (
+          <>
+            <p>로그인이 필요합니다</p>
+            <p>로그인 페이지로 이동하시겠습니까?</p>
+          </>
+        )}
+      </Content>
+      <LinkStyle to={`${page}`}>확인</LinkStyle>
+      <button onClick={handleCloseModal}>취소</button>
+    </Modal>
+  );
+};
+
+const Content = styled.div`
+  line-height: 35px;
+`;
+
+const LinkStyle = styled(Link)`
+  text-decoration: none;
+  color: black;
+  opacity: 0.5;
+  font-size: 20px;
+
+  &:hover {
+    opacity: 1;
+  }
+
+  &:visited {
+    color: black;
+    opacity: 0.5;
+  }
+`;
+
+export default CartConfirmModal;

--- a/src/components/GoodsItem.jsx
+++ b/src/components/GoodsItem.jsx
@@ -1,17 +1,20 @@
-import { faCartPlus, faMagnifyingGlass } from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { Link } from 'react-router';
-import styled from 'styled-components';
+import {
+  faCartPlus,
+  faMagnifyingGlass,
+} from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { Link } from "react-router";
+import styled from "styled-components";
 
 const GoodsItem = ({ item, handleOpenModal }) => {
   return (
     <Container key={item.id}>
       <Buttons>
         <DetailLink to={`/goods-detail/${item.id}`}>
-          <FontAwesomeIcon icon={faMagnifyingGlass} size='2x' />
+          <FontAwesomeIcon icon={faMagnifyingGlass} size="2x" />
         </DetailLink>
-        <button onClick={handleOpenModal}>
-          <FontAwesomeIcon icon={faCartPlus} size='2x' />
+        <button onClick={() => handleOpenModal(item.id, 1)}>
+          <FontAwesomeIcon icon={faCartPlus} size="2x" />
         </button>
       </Buttons>
       <Image src={item.imgUrl} alt={item.title} />

--- a/src/components/GoodsList.jsx
+++ b/src/components/GoodsList.jsx
@@ -1,12 +1,10 @@
-import styled from 'styled-components';
-import { Modal } from './Modal';
-import { useState } from 'react';
-import { Link } from 'react-router';
-import GoodsItem from './GoodsItem';
+import styled from "styled-components";
+import { useState } from "react";
+import GoodsItem from "./GoodsItem";
+import CartConfirmModal from "./CartConfirmModal";
 
-const GoodsList = ({ currentProducts }) => {
+const GoodsList = ({ currentProducts, user }) => {
   const [showModal, setShowModal] = useState(false);
-  const [user, setUser] = useState(null);
 
   function handleOpenModal() {
     setShowModal(true);
@@ -19,27 +17,15 @@ const GoodsList = ({ currentProducts }) => {
   return (
     <>
       {showModal && (
-        <Modal>
-          <Content>
-            {!user ? (
-              <>
-                <p>로그인이 필요합니다</p>
-                <p>로그인 페이지로 이동하시겠습니까?</p>
-              </>
-            ) : (
-              <>
-                <p>장바구니에 담았습니다</p>
-                <p>장바구니 페이지로 이동하시겠습니까?</p>
-              </>
-            )}
-          </Content>
-          <LinkStyle to={'/login'}>확인</LinkStyle>
-          <button onClick={handleCloseModal}>취소</button>
-        </Modal>
+        <CartConfirmModal user={user} handleCloseModal={handleCloseModal} />
       )}
       <Container>
         {currentProducts.map((item) => (
-          <GoodsItem key={item.id} item={item} handleOpenModal={handleOpenModal} />
+          <GoodsItem
+            key={item.id}
+            item={item}
+            handleOpenModal={handleOpenModal}
+          />
         ))}
       </Container>
     </>
@@ -54,24 +40,4 @@ const Container = styled.ul`
   flex-wrap: wrap;
   gap: 10px;
   margin: auto;
-`;
-
-const Content = styled.div`
-  line-height: 35px;
-`;
-
-const LinkStyle = styled(Link)`
-  text-decoration: none;
-  color: black;
-  opacity: 0.5;
-  font-size: 20px;
-
-  &:hover {
-    opacity: 1;
-  }
-
-  &:visited {
-    color: black;
-    opacity: 0.5;
-  }
 `;

--- a/src/components/GoodsList.jsx
+++ b/src/components/GoodsList.jsx
@@ -2,13 +2,43 @@ import styled from "styled-components";
 import { useState } from "react";
 import GoodsItem from "./GoodsItem";
 import CartConfirmModal from "./CartConfirmModal";
+import { addItemToCart } from "../api/cartAPI";
 
 const GoodsList = ({ currentProducts, user }) => {
   const [showModal, setShowModal] = useState(false);
+  const [addedCartItem, setAddedCartItem] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [apiMessage, setApiMessage] = useState(null);
 
-  function handleOpenModal() {
-    setShowModal(true);
-  }
+  const postItemToCart = async (goodId, quantity) => {
+    try {
+      const cartItem = await addItemToCart(goodId, quantity);
+      setAddedCartItem(cartItem);
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // if (loading)  <p>로딩 중...</p>;
+  // if (error) return <p>에러 발생: {error}</p>;
+  // if (!addedCartItem.cartId) return <p>{addedCartItem.message}</p>;
+
+  const handleOpenModal = async (goodId, quantity) => {
+    if (!user) {
+      setShowModal(true);
+      return;
+    }
+
+    try {
+      await postItemToCart(goodId, quantity);
+      setShowModal(true);
+    } catch (err) {
+      console.error("장바구니 추가 중 오류 발생:", err);
+    }
+  };
 
   function handleCloseModal() {
     setShowModal(false);

--- a/src/components/GoodsList.jsx
+++ b/src/components/GoodsList.jsx
@@ -6,25 +6,22 @@ import { addItemToCart } from "../api/cartAPI";
 
 const GoodsList = ({ currentProducts, user }) => {
   const [showModal, setShowModal] = useState(false);
-  const [addedCartItem, setAddedCartItem] = useState(false);
+  const [apiMessage, setApiMessage] = useState("");
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
-  const [apiMessage, setApiMessage] = useState(null);
 
   const postItemToCart = async (goodId, quantity) => {
     try {
-      const cartItem = await addItemToCart(goodId, quantity);
-      setAddedCartItem(cartItem);
+      await addItemToCart(goodId, quantity);
+      setApiMessage("장바구니에 담았습니다. \n 장바구니로 이동하시겠습니까?");
     } catch (err) {
-      setError(err.message);
+      setApiMessage(
+        "장바구니에 담는 것을 실패했습니다. \n 다시 시도해주십시오."
+      );
     } finally {
       setLoading(false);
     }
   };
-
-  // if (loading)  <p>로딩 중...</p>;
-  // if (error) return <p>에러 발생: {error}</p>;
-  // if (!addedCartItem.cartId) return <p>{addedCartItem.message}</p>;
 
   const handleOpenModal = async (goodId, quantity) => {
     if (!user) {
@@ -37,17 +34,23 @@ const GoodsList = ({ currentProducts, user }) => {
       setShowModal(true);
     } catch (err) {
       console.error("장바구니 추가 중 오류 발생:", err);
+      setShowModal(true);
     }
   };
 
-  function handleCloseModal() {
+  const handleCloseModal = () => {
     setShowModal(false);
-  }
+    setApiMessage("");
+  };
 
   return (
     <>
       {showModal && (
-        <CartConfirmModal user={user} handleCloseModal={handleCloseModal} />
+        <CartConfirmModal
+          user={user}
+          handleCloseModal={handleCloseModal}
+          message={apiMessage}
+        />
       )}
       <Container>
         {currentProducts.map((item) => (

--- a/src/pages/Goods.jsx
+++ b/src/pages/Goods.jsx
@@ -6,6 +6,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faAngleDown, faAngleRight } from "@fortawesome/free-solid-svg-icons";
 import { fetchGoods, fetchCategoryGoods } from "../api/goodsAPI";
 import { useNavigate } from "react-router";
+import { getAccessToken } from "../utils/decodeToken";
 
 const Goods = () => {
   const [allProducts, setAllProducts] = useState([]);
@@ -15,8 +16,7 @@ const Goods = () => {
   const [totalPages, setTotalPages] = useState(1);
   const [category, setCategory] = useState("전체");
   const [showCategory, setShowCategory] = useState(false);
-
-  const navigate = useNavigate();
+  const [user, setUser] = useState(null);
 
   const categoryRef = useRef(null);
   const optionListRef = useRef(null);
@@ -90,9 +90,9 @@ const Goods = () => {
     }
   };
 
-  const goToCart = () => {
-    navigate("/cart");
-  };
+  useEffect(() => {
+    setUser(getAccessToken() ? true : false);
+  }, []);
 
   if (isLoading) {
     return <div>로딩 중...</div>;
@@ -124,7 +124,7 @@ const Goods = () => {
             </OptionList>
           )}
         </Category>
-        <GoodsList currentProducts={currentProducts} />
+        <GoodsList currentProducts={currentProducts} user={user} />
       </Container>
       <Pagination
         currentPage={currentPage}

--- a/src/pages/GoodsDetail.jsx
+++ b/src/pages/GoodsDetail.jsx
@@ -7,8 +7,9 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { useEffect, useState } from "react";
 import { Link, useParams } from "react-router";
 import styled from "styled-components";
-import { Modal } from "../components/Modal";
 import { fetchGoodDetails } from "../api/goodDetailsAPI";
+import CartConfirmModal from "../components/CartConfirmModal";
+import { getAccessToken } from "../utils/decodeToken";
 
 const GoodsDetail = () => {
   const [showModal, setShowModal] = useState(false);
@@ -33,6 +34,10 @@ const GoodsDetail = () => {
     getGoodsDetails();
   }, [id]);
 
+  useEffect(() => {
+    setUser(getAccessToken() ? true : false);
+  }, []);
+
   function handleAddCart() {
     setShowModal(true);
   }
@@ -47,23 +52,7 @@ const GoodsDetail = () => {
   return (
     <Container>
       {showModal && (
-        <Modal>
-          <Content>
-            {!user ? (
-              <>
-                <p>로그인이 필요합니다</p>
-                <p>로그인 페이지로 이동하시겠습니까?</p>
-              </>
-            ) : (
-              <>
-                <p>장바구니에 담았습니다</p>
-                <p>장바구니 페이지로 이동하시겠습니까?</p>
-              </>
-            )}
-          </Content>
-          <LinkStyle to={"/login"}>확인</LinkStyle>
-          <button onClick={handleCloseModal}>취소</button>
-        </Modal>
+        <CartConfirmModal user={user} handleCloseModal={handleCloseModal} />
       )}
 
       <ListLink to={"/goods"}>
@@ -163,25 +152,5 @@ const Buttons = styled.div`
     border: none;
     background: transparent;
     cursor: pointer;
-  }
-`;
-
-const Content = styled.div`
-  line-height: 35px;
-`;
-
-const LinkStyle = styled(Link)`
-  text-decoration: none;
-  color: black;
-  opacity: 0.5;
-  font-size: 20px;
-
-  &:hover {
-    opacity: 1;
-  }
-
-  &:visited {
-    color: black;
-    opacity: 0.5;
   }
 `;

--- a/src/utils/reissueTokenApi.js
+++ b/src/utils/reissueTokenApi.js
@@ -1,4 +1,3 @@
-import axios from "axios";
 import { api } from "./api";
 
 // ✅ access token 재발급 함수 (API 요청 실패 시 호출됨)


### PR DESCRIPTION
## 🛠 작업 내용
### 1. 장바구니 이동 모달을 컴포넌트로 분리 및 적용
- `CartConfirmModal` 컴포넌트를 생성하여 모달 내용을 별도 파일로 분리
- 부모 컴포넌트에서 `user` 상태를 props로 전달하도록 수정
- `useEffect`를 활용해 최초 렌더링 시 access token을 확인하여 `user` 상태 업데이트
- `handleCloseModal`을 props로 전달하여 모달 닫기 기능 적용

📂 **파일 참고**
- `components/CartConfirmModal.jsx`

---

### 2. **장바구니 추가 API 생성 및 굿즈 메인 페이지에 연동**
- `cartAPI.js`에 `addItemToCart` API 생성 → `goodId`, `quantity`, `userId`를 전송하여 장바구니에 상품 추가 요청
- `authApi` 사용하여 Token 재발급 가능
- `handleOpenModal` 로직 수정 → `goodId`, `quantity`를 `GoodsItem.jsx`에서 props로 전달받아 로그인 시 API 호출  
  **로그인이 아닌 경우, API 호출 없이 모달만 표시**

📂 **파일 참고**
- `api/cartAPI.js`
- `components/GoodsItem.jsx`

---

### 3. **장바구니 추가 메시지 커스텀 및 모달 표시 개선**
- 장바구니 추가 성공/실패 메시지를 프론트에서 커스텀 처리
  - ✅ **성공:** `"장바구니에 담았습니다. \n 장바구니로 이동하시겠습니까?"`
  - ❌ **실패:** `"장바구니에 담는 것을 실패했습니다. \n 다시 시도해주십시오."`
- `apiMessage` 상태 추가 → 모달에서 메시지 출력 가능하도록 수정
- 모달 내 텍스트 줄바꿈 적용 (`white-space: pre-line;`)

📂 **파일 참고**
- `components/CartConfirmModal.jsx`
- `components/GoodsList.jsx`

---

### 4. **불필요한 라이브러리 정리**
- 사용하지 않는 라이브러리(`axios`) 삭제하여 코드 정리

📂 **파일 참고**
- `utils/reissueApi.js`

